### PR TITLE
[Refactor] SSE에서 웹소켓 전환

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -8,7 +8,7 @@ interface ChatMessageCardProps {
 
 const ChatMessage: React.FC<ChatMessageCardProps> = ({ message }) => {
     const localUser = JSON.parse(localStorage.getItem('user') || '{}');
-    const isOwnMessage = localUser.email === 'test@test.com';
+    const isOwnMessage = localUser.email
     const isMessageType = message.type === "MESSAGE";
 
     // 입장/퇴장 메시지 처리

--- a/src/components/chat/ChatParticipants.tsx
+++ b/src/components/chat/ChatParticipants.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { RootState } from "../../redux/store";
 import { useAppSelector } from "../../redux/hooks";
 import { ReadUsersContainer, ParticipantContainer } from "../../styles/ChatStyles";
+import { initializeParticipantClient } from "../../util/WebSocketClient";
 // import { EventSourcePolyfill } from "event-source-polyfill";
 
 interface UserReadDTO {
@@ -11,37 +12,20 @@ interface UserReadDTO {
 
 const ChatParticipants :React.FC = () => {
     const [participants, setParticipants] = useState<UserReadDTO[]>([]);
-
     const chat = useAppSelector((state: RootState) => state.chat);
 
-    // const accessTokenValue = document.cookie.split('Bearer%20')[1];
-    // const accessToken = 'Bearer%20' + accessTokenValue;
-
     useEffect(() => {
-        const eventSource = new EventSource(
-            `${process.env.REACT_APP_API_BASE_URL}/participants/${chat.chatId}`,
-            {
-                withCredentials: true
-            }
-        );
+        initializeParticipantClient(chat.chatId, (message: UserReadDTO[]) => {
+            setParticipants(message);
+        });
 
-        eventSource.onmessage = (event) => {
-            const updateParticipants = JSON.parse(event.data);
-            console.log("SSE 데이터: " + updateParticipants);
-            setParticipants(updateParticipants)
-        }
-
-        eventSource.onerror = (error) => {
-            console.error('EventSource failed:', error);
-            eventSource.close(); // 에러 발생 시 연결 종료
-        };
-
-        return () => {
-            eventSource.close(); // 컴포넌트 언마운트 시 연결 종료
-        };
     }, [chat]);
 
-    const { readParticipants, unreadParticipants } = participants.reduce((acc, participant) => {
+    console.log("받아온 데이터: " + participants);
+    console.log("배열이긴 해?: "+ Array.isArray(participants));
+    const participantList = Array.isArray(participants) ? participants : [];
+
+    const { readParticipants, unreadParticipants } = participantList.reduce((acc, participant) => {
         if (participant.isRead) {
             acc.readParticipants.push(participant);
         } else {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -9,6 +9,7 @@ import { RootState } from "../redux/store";
 import { useNavigate } from "react-router-dom";
 import { justUnreadChats } from "../api/ChatApi";
 import ChatParticipants from "../components/chat/ChatParticipants";
+import { justLeave } from "../util/WebSocketClient";
 
 const ChatPage: React.FC = () => {
     // const { chatId } = useParams<{ chatId: string }>(); // URL 파라미터에서 chatId 추출
@@ -17,6 +18,7 @@ const ChatPage: React.FC = () => {
 
     const handleGoToListClick = () => {
         justUnreadChats(chat.chatId);
+        justLeave(chat.chatId);
         localStorage.removeItem("chat");
         navigate("/")
     }

--- a/src/util/ParticipantClient.ts
+++ b/src/util/ParticipantClient.ts
@@ -1,0 +1,36 @@
+import SockJS from 'sockjs-client';
+import Stomp from 'stompjs';
+
+interface UserReadDTO {
+    email: string;
+    isRead: boolean;
+}
+
+let stompClient: any = null;
+
+let endpoint: string | undefined = process.env.REACT_APP_API_BASE_URL
+endpoint = endpoint?.slice(0, -4)
+
+export const initializeWebSocketClient = (
+    chatId: string,
+    onMessage: (message: UserReadDTO[]) => void
+) => {
+    const sockJs = new SockJS(endpoint + `/stomp/participant`);
+    stompClient = Stomp.over(sockJs);
+
+    // 쿠키에서 토큰 추출
+    // const accessToken = document.cookie.split('Bearer%20')[1];
+
+    stompClient.connect(
+        // { Authorization: `Bearer ${accessToken}` },
+        {}, // 빈 헤더라도 넘겨줘야 함
+        () => {
+            stompClient.subscribe(`/sub/participant/${chatId}`, (participants: any) => {
+                const message = JSON.parse(participants.body);
+                onMessage(message);
+            });
+        }
+    );
+
+    return stompClient;
+};


### PR DESCRIPTION
## 웹소켓 로직 전역화 및 상태공유 정합성
- SSE의 단점을 파악하고 구독자 관리 역시 웹소켓으로 처리하는 것으로 결정, 전환
- 채팅창을 벗어나는 것이 곧 웹소켓 구독 종료이기 때문에 **채팅 메세징 웹소켓**과 **구독자 참여 웹소켓**의 일관적인 관리 필요
- 구독 종료 시점의 일원화를 통한 전역적 웹소켓 관리 처리

```js
let stompClient: any = null;
let particpantStompClient:any = null;

// ...

export const justLeave = (chatId: string) => {
    if (stompClient) {
        stompClient.disconnect();
        localStorage.removeItem("chat")
    }

    if (particpantStompClient) {
        particpantStompClient.disconnect();
    }
};

export const deactivate = (chatId: string) => {
    if (stompClient) {
        stompClient.send(
            '/send/chat/leave',
            {},
            JSON.stringify({
                chatId: chatId
            })
        );

        stompClient.disconnect();
        localStorage.removeItem("chat")
    }

    if (particpantStompClient) {
        particpantStompClient.disconnect();
    }
};

```
```js
// 채팅 메세징 컴포넌트

const Chat: React.FC = () => {
    const [messages, setMessages] = useState<ChatMessageDTO[]>([]);
    
    // ...

    useEffect(() => {
        initializeWebSocketClient(chat.chatId, (message: ChatMessageDTO) => {
            console.log("받은 메세지: " + message.message)
            setMessages(prevMessages => [...prevMessages, message]);
        });

    }, [chat]);
```
```js
// 채팅 참여 관리 컴포넌트

const ChatParticipants :React.FC = () => {
    const [participants, setParticipants] = useState<UserReadDTO[]>([]);
    const chat = useAppSelector((state: RootState) => state.chat);

    useEffect(() => {
        initializeParticipantClient(chat.chatId, (message: UserReadDTO[]) => {
            setParticipants(message);
        });

    }, [chat]);
```
- 전역 관리 확인