### PR TITLE
[채팅방] 현재 인원 필드 업데이트

### DIFF
--- a/src/components/chat/OpenChat.tsx
+++ b/src/components/chat/OpenChat.tsx
@@ -9,6 +9,7 @@ interface ChatInfo {
     chatId: string;
     title: string;
     openUsername: string;
+    personnel: number;
     maxPersonnel: number;
 }
   
@@ -80,7 +81,7 @@ const OpenChat: React.FC = () => {
                     <ChatCardContainer key={chat.chatId} onClick={() => handleChatClick(chat)}>
                         <h4>{chat.title}</h4>
                         <p>Host: {chat.openUsername}</p>
-                        <p>Max Personnel: {chat.maxPersonnel}</p>
+                        <p>{chat.personnel} / {chat.maxPersonnel}</p>
                     </ChatCardContainer>
                 ))}
             </OpenChatListContainer>

--- a/src/components/user/SubscribeChat.tsx
+++ b/src/components/user/SubscribeChat.tsx
@@ -9,6 +9,7 @@ interface ChatInfo {
     chatId: string;
     title: string;
     openUsername: string;
+    personnel: number;
     maxPersonnel: number;
 }
 

--- a/src/redux/chatSlice.ts
+++ b/src/redux/chatSlice.ts
@@ -4,6 +4,7 @@ interface ChatState {
     chatId: string;
     title: string;
     openUsername: string;
+    personnel: number;
     maxPersonnel: number;
 }
 
@@ -12,6 +13,7 @@ const initialState: ChatState = savedChat ? JSON.parse(savedChat) : {
     chatId: '',
     title: '',
     openUsername: '',
+    personnel: 0,
     maxPersonnel: 0,
 };
 
@@ -23,6 +25,7 @@ const chatSlice = createSlice({
             state.chatId = action.payload.chatId;
             state.title = action.payload.title;
             state.openUsername = action.payload.openUsername;
+            state.personnel = action.payload.personnel;
             state.maxPersonnel = action.payload.maxPersonnel;
 
             localStorage.setItem("chat", JSON.stringify(state));
@@ -31,6 +34,7 @@ const chatSlice = createSlice({
             state.chatId = '';
             state.title = '';
             state.openUsername = '';
+            state.personnel = 0;
             state.maxPersonnel = 0;
 
             localStorage.removeItem("chat");


### PR DESCRIPTION
## 서버 사이드 엔티티 필드 변화에 따른 클라이언트 코드 수정

### 백엔드 코드

```java
@Getter
@Setter
@Entity
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Table(name = "openchats")
@EntityListeners(AuditingEntityListener.class)
public class ChatRoom {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "id")
    private Long id;

    // ...

    @Column(name = "personnel")
    private Integer personnel;

    // ...
```

- 필드 추가로 인해 응답 DTO에서도 필드 추가,  클라이언트 활용 필요
- 해당 필드는 향후 입장 인원 제어에서 활용

### 프론트엔드 코드

```ts
interface ChatInfo {
    chatId: string;
    title: string;
    openUsername: string;
    personnel: number;
    maxPersonnel: number;
}
  
const OpenChat: React.FC = () => {
    const [chats, setChats] = useState<ChatInfo[]>([]);
    
    // ...

    return (
        <>
            <OpenChatListContainer>
                {chats.map((chat) => (
                    <ChatCardContainer key={chat.chatId} onClick={() => handleChatClick(chat)}>
                        <h4>{chat.title}</h4>
                        <p>Host: {chat.openUsername}</p>
                        <p>{chat.personnel} / {chat.maxPersonnel}</p>
                    </ChatCardContainer>
                ))}

    // ...
```
- 최대 인원 대비 현재 채팅방 인원을 보여주는 형식으로 구현
- 인원 제한 클라이언트측 코드 수정 종료